### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -437,10 +437,13 @@ export const highlight = (
 		let i: number
 
 		for (i = 0; i < pathValue.length - 1; i++) {
+			if (pathValue[i] === "__proto__" || pathValue[i] === "constructor") return
 			obj = obj[pathValue[i]] as Record<string, any>
 		}
 
-		obj[pathValue[i]] = value
+		if (pathValue[i] !== "__proto__" && pathValue[i] !== "constructor") {
+			obj[pathValue[i]] = value
+		}
 	}
 
 	// Function to merge overlapping regions


### PR DESCRIPTION
Fixes [https://github.com/lloydchang/cline-cline-fka-saoudrizwan-claude-dev/security/code-scanning/2](https://github.com/lloydchang/cline-cline-fka-saoudrizwan-claude-dev/security/code-scanning/2)

To fix the prototype pollution vulnerability, we need to ensure that the `set` function does not allow modification of the `__proto__` or `constructor` properties. This can be achieved by adding a check to block these property names before performing the assignment.

- Modify the `set` function to include a check that skips any property names that are `__proto__` or `constructor`.
- This change should be made in the `webview-ui/src/components/history/HistoryView.tsx` file, specifically within the `set` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
