### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -1,4 +1,5 @@
 import { Anthropic } from "@anthropic-ai/sdk"
+import { URL } from "url";
 import OpenAI, { AzureOpenAI } from "openai"
 import {
 	ApiHandlerOptions,
@@ -17,7 +18,9 @@ export class OpenAiHandler implements ApiHandler {
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
 		// Azure API shape slightly differs from the core API shape: https://github.com/openai/openai-node?tab=readme-ov-file#microsoft-azure-openai
-		if (this.options.openAiBaseUrl?.toLowerCase().includes("azure.com")) {
+		const url = new URL(this.options.openAiBaseUrl);
+		const allowedHosts = ["azure.com", "subdomain.azure.com"];
+		if (allowedHosts.includes(url.host)) {
 			this.client = new AzureOpenAI({
 				baseURL: this.options.openAiBaseUrl,
 				apiKey: this.options.openAiApiKey,


### PR DESCRIPTION
Fixes [https://github.com/lloydchang/cline-cline-fka-saoudrizwan-claude-dev/security/code-scanning/1](https://github.com/lloydchang/cline-cline-fka-saoudrizwan-claude-dev/security/code-scanning/1)

To fix the problem, we need to parse the URL and check the host value against a whitelist of allowed hosts. This ensures that the host is explicitly verified and not just a substring within the URL. 

1. Parse the URL using a URL parsing library.
2. Extract the host from the parsed URL.
3. Check if the host is in a predefined list of allowed hosts.
4. Update the code to use this secure check instead of the substring check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
